### PR TITLE
Remove xsa-131 from the patchqueue when building

### DIFF
--- a/recipes-xt/qemu-dm/qemu-dm-stubdom_1.4.0.bbappend
+++ b/recipes-xt/qemu-dm/qemu-dm-stubdom_1.4.0.bbappend
@@ -1,0 +1,8 @@
+python () {
+	import string
+
+	rdeps = bb.data.getVar("SRC_URI", d)
+	rdeps = string.replace(rdeps, 'file://xsa-131-unmediated-pci-register-access-in-qemu.patch;patch=1', '')
+	bb.data.setVar("SRC_URI", rdeps, d)
+
+}

--- a/recipes-xt/qemu-dm/qemu-dm_1.4.0.bbappend
+++ b/recipes-xt/qemu-dm/qemu-dm_1.4.0.bbappend
@@ -1,0 +1,8 @@
+python () {
+	import string
+
+	rdeps = bb.data.getVar("SRC_URI", d)
+	rdeps = string.replace(rdeps, 'file://xsa-131-unmediated-pci-register-access-in-qemu.patch;patch=1', '')
+	bb.data.setVar("SRC_URI", rdeps, d)
+
+}


### PR DESCRIPTION
This bbappend can be removed when this xsa is fixed to resolve
the broadcom nic passthrough blue screen in windows guests.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>